### PR TITLE
Better error messages on invalid dtype.

### DIFF
--- a/src/scitiff/io.py
+++ b/src/scitiff/io.py
@@ -106,11 +106,13 @@ def to_scitiff_image(da: sc.DataArray) -> sc.DataArray:
 
 
 def _validate_dtypes(da: sc.DataArray) -> None:
-    # Checking int8 and int16 as string because scipp currently does not have
+    # Checking int8 and int16 as well because scipp currently does not have
     # dtype of int8 and int16, but may have in the future.
-    # We will replace this to use the DType module when it is available later.
-    # So that we don't have any hard-coded values in the source code.
-    if da.dtype != sc.DType.float32 or str(da.dtype) not in ("int8", "int16"):
+    # We are checking dtype in advance to the ``tifffile.imwrite`` function
+    # raises an error, because the error message is not clear.
+    # i.e. ValueError: the ImageJ format does not support data type 'd'
+    # when the dtype is float64.
+    if str(da.dtype) not in ("int8", "int16", "float32"):
         raise sc.DTypeError(
             f"DataArray has unexpected dtype: {da.dtype}. "
             "ImageJ only supports float32, int8, and int16 dtypes. "

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -63,3 +63,10 @@ def test_load_squeeze_false(sample_image, tmp_path) -> None:
     save_scitiff(sample_image, tmp_file_path)
     loaded_image = load_scitiff(tmp_file_path, squeeze=False)
     assert loaded_image.dims == SCITIFF_IMAGE_STACK_DIMENSIONS
+
+
+def test_save_wrong_dtype_raises(sample_image: sc.DataArray) -> None:
+    with pytest.raises(sc.DTypeError, match='DataArray has unexpected dtype: int64'):
+        save_scitiff(sample_image.astype(int), 'test.tiff')
+    with pytest.raises(sc.DTypeError, match='DataArray has unexpected dtype: float64'):
+        save_scitiff(sample_image.astype(float), 'test.tiff')


### PR DESCRIPTION
ImageJ mode tiff files only allow `float32`, `int8` and `int16` and scipp only supports `float32`.